### PR TITLE
Fix for xdist-grouping

### DIFF
--- a/pytest_reporter/plugin.py
+++ b/pytest_reporter/plugin.py
@@ -115,10 +115,10 @@ class ReportGenerator:
         self._reports = set()
 
     def _get_testrun(self, nodeid):
-        testrun = self._active_tests.get(nodeid)
+        testrun = self._active_tests.get(nodeid.split('@', 1)[0])
         if testrun is None:
             testrun = {
-                "item": self._items.get(nodeid),
+                "item": self._items.get(nodeid.split('@', 1)[0]),
                 "phases": [],
             }
             self._active_tests[nodeid] = testrun
@@ -134,7 +134,7 @@ class ReportGenerator:
         self.context["items"] = self._items
 
     def pytest_runtest_logstart(self, nodeid):
-        testrun = self._get_testrun(nodeid)
+        testrun = self._get_testrun(nodeid.split('@', 1)[0])
         testrun["started"] = time.time()
 
     @pytest.hookimpl(hookwrapper=True)
@@ -164,7 +164,7 @@ class ReportGenerator:
         testrun = self._get_testrun(nodeid)
         testrun["ended"] = time.time()
         self.context["tests"].append(testrun)
-        del self._active_tests[nodeid]
+        del self._active_tests[nodeid.split('@', 1)[0]]
 
     # the pytest_warning_recorded hook was introduced in pytest 6.0
     if hasattr(_pytest.hookspec, "pytest_warning_recorded"):


### PR DESCRIPTION
@christiansandberg 
Please have a look.

While using marker @pytest.mark.xdist_group for a test as below and running with command --dist=loadgroup, report does not get generated.

**Issue looks like:**
nodeid comes as module::class::method**@group**
The one above in bold creates issue, and does not create report.

**Script example:** 
tests\test_first.py

class TestA:
   @pytest.mark.xdist_group("group1")
   def test1():
      pass

**Run as:**
pytest tests\test_first -n 1 --dist loadgroup

**Attached error:**
[Xdist.grp.html.report.issue.txt](https://github.com/christiansandberg/pytest-reporter/files/11983644/Xdist.grp.html.report.issue.txt)
